### PR TITLE
Use newer version gcc on osx

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,7 @@
     {
       "target_name": "native",
       "sources": ["src/native.cc", "src/LRUCache.cc"],
-      "cflags": [ "-std=c++0x", "-O2" ],
+      "cflags": [ "-std=c++11", "-O2" ],
       "include_dirs" : [
         "<!(node -e \"require('nan')\")"
       ]

--- a/src/LRUCache.h
+++ b/src/LRUCache.h
@@ -8,13 +8,8 @@
 
 using namespace v8;
 
-#ifdef __APPLE__
-#include <tr1/unordered_map>
-#define unordered_map std::tr1::unordered_map
-#else
 #include <unordered_map>
 #define unordered_map std::unordered_map
-#endif
 
 class LRUCache : public Nan::ObjectWrap {
 


### PR DESCRIPTION
* unordered_map is a form of map containter, use
unordered_map::find(KeyType key) instead, which returns
unordered_map::iterator, essentially pointer tostd::pair< KeyType,
ValueType >.

Or you can use unordered_map::operator[](KeyType key) to get access to
element pointed by the key variable. Note that it will create new
element in case it doesn't exist yet.

See http://en.cppreference.com/w/cpp/container/unordered_map for more info.

* Use newer GCC (at least 4.7) with -std=c++11 option, and you will get
standardized std::unordered_map instead of tr1::unordered_map

Fix #9