### PR TITLE
Fix: make all options optional in typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,8 +2,8 @@ declare module "lru-native2" {
   interface LRUCacheOptions {
     maxElements?: number
     maxAge?: number
-    size: number
-    maxLoadFactor: number
+    size?: number
+    maxLoadFactor?: number
   }
 
   interface LRUCacheStats {
@@ -17,7 +17,7 @@ declare module "lru-native2" {
   type K = string
 
   class LRUCache<V> {
-    constructor(options: LRUCacheOptions)
+    constructor(options?: LRUCacheOptions)
 
     public set(key: K, value: V): void
     public get(key: K): V | undefined


### PR DESCRIPTION
This PR fixes the typescript typings to reflect what the constructor actually takes. Looking at [the constructor](https://github.com/adzerk/node-lru-native/blob/master/src/LRUCache.cc#L95-L118), all the options are optional, and you can omit options entirely if you're happy with the defaults. There's even [a test](https://github.com/adzerk/node-lru-native/blob/master/test/basics.tests.js#L8) for this.

This was a bit of a pain point for me, because at the moment `maxLoadFactor` is required, and you have to go digging through c++ documentation to work out that [the default is 1.0](https://www.cplusplus.com/reference/unordered_map/unordered_map/max_load_factor/) for an unordered map.